### PR TITLE
modified endID and draw_arrow functions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,9 @@ RUN pip3 install -r requirements.txt
 # CMD ["node", "app.js"]
 
 # Copy in run scripts
-COPY cwl_graph_generate.* ./
+COPY cwl_graph_generate.* .
+
+# Set execute permissions for the Python script and shell script
+RUN chmod +x /opt/cwl_graph_generate.py /opt/cwl_graph_generate.sh
 
 ENTRYPOINT [ "/opt/cwl_graph_generate.sh" ]

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ $ docker run --rm -ti -v $PWD:$PWD -w $PWD cwl-graph-generate $CWL_FILE
 ## Limitations
 
 This project was created with the sole purpose of creating the graph above, so the code is not written from a standpoint of maintainability or stability.
+
+## Running the Unit Tests
+
+To run all unit tests, you can use the following command:
+
+```sh
+python3 -m unittest discover -s unit_tests
+

--- a/unit_tests/test_cwl_graph_generate_draw_arrow.py
+++ b/unit_tests/test_cwl_graph_generate_draw_arrow.py
@@ -1,0 +1,127 @@
+import unittest
+import sys
+import os
+import io
+
+"""
+Unit Tests for the get_workflow_dot Function (draw_arrow sub-function) in cwl_graph_generate.py
+The function draw_arrow can wait forever without throwing an assertion error due to the use of pdb.set_trace() in the except block. This causes the program to pause execution and wait for user input indefinitely. By removing or modifying the debugger call, the function doesn't enter an indefinite waiting. May be another simple fix can be to remove the pdb call in the except and simply catch the assertion error as follows.  
+
+except AssertionError as e:
+        _logger.error(f"Assertion failed: {str(e)}")
+
+Context:
+The original implementation of the draw_arrow sub-function contained assertions that could halt execution if certain conditions were not met. Specifically, it would halt if source_num or target_num were None for file-based inputs or outputs. This behavior was problematic in production as it could stop the entire workflow execution. To address this, the assertions were replaced with warnings, allowing the function to continue executing and improving overall reliability.
+
+These tests ensure that the get_workflow_dot function:
+1. Properly generates warnings instead of halting when source_num or target_num is None.
+2. Continues execution and completes graph generation without interruption, ensuring robustness.
+
+Test Cases:
+1. test_warning_for_none_source_num:
+    - Verifies that a warning is generated when source_num is None for a file-based input.
+
+2. test_warning_for_none_target_num:
+    - Checks that a warning is generated when target_num is None for a file-based output.
+
+3. test_no_warnings_for_non_file_based:
+    - Ensures that no warnings are produced for non-file-based inputs and outputs.
+
+4. test_non_halting_behavior:
+    - Ensures that the function completes graph generation without interruption even when warnings are generated.
+    - Verifies that the function continues executing and generating arrows despite warnings, improving reliability.
+"""
+
+# Add the parent directory to the Python path
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import cwl_graph_generate
+from cwl_graph_generate import get_workflow_dot, ids_by_workflow
+
+class MockCommandLineTool:
+    def __init__(self):
+        self.tool = {"inputs": [{"id": "in1"}], "outputs": [{"id": "out"}]}
+
+class TestWorkflowDot(unittest.TestCase):
+    def setUp(self):
+        cwl_graph_generate.indent_level = 0
+        ids_by_workflow.clear()
+        self.held_stderr = io.StringIO()
+        self.original_stderr = sys.stderr
+        sys.stderr = self.held_stderr
+
+    def tearDown(self):
+        sys.stderr = self.original_stderr
+
+    def create_tool(self, input_id, output_id):
+        class SimpleTool:
+            def __init__(self):
+                self.tool = {
+                    "id": "test_workflow",
+                    "inputs": [{"id": input_id}],
+                    "outputs": [{"id": output_id, "outputSource": "step1/out"}],
+                    "steps": [{
+                        "id": "step1",
+                        "in": [{"id": "in1", "source": input_id, "valueFrom": "$(inputs.input1)"}],
+                        "out": [{"id": "out"}]
+                    }]
+                }
+                self.steps = [type('Step', (), {
+                    'id': 'step1',
+                    'tool': {
+                        "inputs": [{"id": "in1", "source": input_id, "valueFrom": "$(inputs.input1)"}],
+                        "outputs": [{"id": "out"}]
+                    },
+                    'embedded_tool': MockCommandLineTool()
+                })()]
+        return SimpleTool()
+
+    def test_warning_for_none_source_num(self):
+        tool = self.create_tool("file://input/path", "out")
+        cwl_graph_generate.CommandLineTool = MockCommandLineTool
+        get_workflow_dot(tool, 1, "test_workflow_id")
+        output = self.held_stderr.getvalue()
+        self.assertIn("[WARNING_ARROW] source_num is None for file-based source: file://input/path", output)
+
+    def test_warning_for_none_target_num(self):
+        tool = self.create_tool("in", "file://output/path")
+        cwl_graph_generate.CommandLineTool = MockCommandLineTool
+        get_workflow_dot(tool, 1, "test_workflow_id")
+        output = self.held_stderr.getvalue()
+        self.assertIn("[WARNING_ARROW] target_num is None for file-based target: file://output/path", output)
+
+    def test_no_warnings_for_non_file_based(self):
+        tool = self.create_tool("in", "out")
+        cwl_graph_generate.CommandLineTool = MockCommandLineTool
+        get_workflow_dot(tool, 1, "test_workflow_id")
+        output = self.held_stderr.getvalue()
+        self.assertNotIn("[WARNING_ARROW] source_num is None", output)
+        self.assertNotIn("[WARNING_ARROW] target_num is None", output)
+
+    def test_non_halting_behavior(self):
+        tool = self.create_tool("file://input/path", "file://output/path")
+        cwl_graph_generate.CommandLineTool = MockCommandLineTool
+        
+        try:
+            get_workflow_dot(tool, 1, "test_workflow_id")
+        except Exception as e:
+            self.fail(f"get_workflow_dot raised an exception: {str(e)}")
+        
+        output = self.held_stderr.getvalue()
+        
+        # Check that both warnings were logged
+        self.assertIn("[WARNING_ARROW] source_num is None for file-based source: file://input/path", output)
+        self.assertIn("[WARNING_ARROW] target_num is None for file-based target: file://output/path", output)
+        
+        # Check for debug messages that indicate the function continued executing
+        self.assertIn("[DEBUG_ARROW] Drawing arrow from file://input/path to value_from_node", output)
+        self.assertIn("[DEBUG_ARROW] Drawing arrow from value_from_node", output)
+        self.assertIn("[DEBUG_ARROW] Drawing arrow from step1 to file://output/path", output)
+        
+        # Check that arrow strings were generated after the warnings
+        self.assertIn('[DEBUG_ARROW] Generated arrow string: "file://input/path" -> "value_from_node', output)
+        self.assertIn('[DEBUG_ARROW] Generated arrow string: "value_from_node', output)
+        self.assertIn('[DEBUG_ARROW] Generated arrow string: "step1" -> "file://output/path"', output)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_cwl_graph_generate_endID.py
+++ b/unit_tests/test_cwl_graph_generate_endID.py
@@ -1,0 +1,68 @@
+import unittest
+from unittest.mock import patch
+from io import StringIO
+from cwl_graph_generate import endId, strip_path  # Import the functions from 'cwl_graph_generate.py'
+
+
+"""
+Unit Tests for the endId Function in cwl_graph_generate.py
+The endId function might not pick the conditional variable (like run_manta_step) which is also an operational variable because it relies on the exact ID matching in embedded_tool_part, but conditional variables are often evaluated at runtime, and their presence in the embedded_tool_part might not be guaranteed or they might not be handled the same way as regular IDs.
+
+These tests ensure that the endId function robustly handles different scenarios that are likely to occur in CWL workflows where IDs might serve dual roles as both operational parameters and control parameters:
+
+1. test_end_id_with_exact_match: Verifies that the function correctly identifies and returns a matching ID when present. This is crucial for steps in the workflow that depend on specific IDs being accurately recognized and processed.
+
+2. test_end_id_with_no_match: Ensures that the function returns the original tool_id when no matching ID is found. This case is important for handling situations where an ID, expected as a control parameter, does not match any operational parameters, allowing the workflow to continue without error.
+
+3. test_end_id_with_empty_list: Tests the function's behavior when no IDs are available to match against, ensuring it returns the original tool_id. This scenario supports workflows with optional inputs or configurations, maintaining smooth execution.
+
+4. test_non_existing_id: Confirms that the function returns the original tool_id when the provided ID does not exist among the operational parameters. This test is crucial for workflows where control parameters might be misinterpreted as data inputs, ensuring that such mismatches do not disrupt the workflow's execution.
+
+These tests collectively ensure that endId effectively supports workflow flexibility and robustness, handling variations in ID usage without causing failures.
+"""
+
+class TestEndIdFunction(unittest.TestCase):
+    def test_end_id_with_exact_match(self):
+        """Test endId returns the correct ID when an exact match is found."""
+        tool_id = "tool#123"
+        embedded_tool_part = [{"id": "tool#123"}, {"id": "tool#456"}]
+        expected = "tool#123"
+        with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            result = endId(tool_id, embedded_tool_part)
+            self.assertEqual(result, expected)
+            self.assertIn("[DEBUG_MATCH]", mock_stderr.getvalue(), "Expected debug message for match not found")
+
+    def test_end_id_with_no_match(self):
+        """Test endId returns the original tool_id when no match is found."""
+        tool_id = "tool#789"
+        embedded_tool_part = [{"id": "tool#123"}, {"id": "tool#456"}]
+        expected = "tool#789"
+        with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            result = endId(tool_id, embedded_tool_part)
+            self.assertEqual(result, expected)
+            self.assertIn("[DEBUG_NOMATCH]", mock_stderr.getvalue(), "Expected debug message for no match not found")
+
+    def test_end_id_with_empty_list(self):
+        """Test endId returns the original tool_id when the list is empty."""
+        tool_id = "tool#000"
+        embedded_tool_part = []
+        expected = "tool#000"
+        with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            result = endId(tool_id, embedded_tool_part)
+            self.assertEqual(result, expected)
+            self.assertIn("[DEBUG_NOMATCH]", mock_stderr.getvalue(), "Expected debug message for empty list not found")
+
+    def test_non_existing_id(self):
+        """Test endId with a tool_id that does not exist in the embedded_tool_part."""
+        tool_id = "path/to/analysis_tool_b"
+        embedded_tool_part = [{"id": "tool#123"}, {"id": "path/to/analysis_tool_a"}]
+        expected = "path/to/analysis_tool_b"
+        with patch('sys.stderr', new_callable=StringIO) as mock_stderr:
+            result = endId(tool_id, embedded_tool_part)
+            self.assertEqual(result, expected)
+            self.assertIn("[DEBUG_NOMATCH]", mock_stderr.getvalue(), "Expected debug message for non-existing ID not found")
+
+# Run the tests
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
`endID` function in the original code is raising `NotImplementedError` if the function can't find a matching id in the `embedded_tool_part` and/or the `tool_id` doesn't correspond to any of the ids in `embedded_tool_part`. This is interrupting with the CWL scripts that involve conditional execution of steps [for instance when there is no matched step inside the subworkflows]. Relaxed it to return the original `tool_id` if no match is found along with DEBUG information to correct the workflow variables. 

`draw_arrow` function is getting stuck and running forever on verifying some cwl scripts with a huge wait at try catch block of asserting `not None` for `source_num` and `target_num`. Relaxed the assertion checks with conditional check with warnings and added more debug try catch blocks to make the script proceed with the graph generation. 